### PR TITLE
Fix map operation error handling to raise on system errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ src/tinybpf/
 
 4. **Context managers**: `BpfObject` and `BpfLink` implement `__enter__`/`__exit__` for automatic resource cleanup.
 
+5. **Error handling**: libbpf functions return `-errno` directly (not -1 with errno set via C library). Use `abs(ret)` to extract the error code, not `ctypes.get_errno()`. See `_check_err()` in `_object.py` for the canonical pattern.
+
 ### Test Requirements
 
 - `test_api.py` and `test_version.py`: No special requirements


### PR DESCRIPTION
## Summary

- Fix `BpfMap.lookup()`, `delete()`, and `keys()` to properly distinguish between "key not found" (ENOENT) and system errors
- ENOENT returns None/False/stops iteration (dict-like behavior)
- System errors now raise `BpfError` with actual error message instead of being silently swallowed
- Add documentation about libbpf's `-errno` return convention

Fixes #4

## Test plan

- [x] All 25 existing tests pass
- [x] `lookup()` returns `None` for missing keys
- [x] `delete()` returns `False` for missing keys
- [x] `__getitem__()` raises `KeyError` for missing keys
- [x] `keys()` iteration completes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)