### PR TITLE
Add ring buffer support

### DIFF
--- a/src/tinybpf/__init__.py
+++ b/src/tinybpf/__init__.py
@@ -22,6 +22,7 @@ from tinybpf._object import (
     BpfObject,
     BpfProgram,
     BpfProgType,
+    BpfRingBuffer,
     MapCollection,
     MapInfo,
     ProgramCollection,
@@ -47,6 +48,7 @@ __all__ = [
     "BpfProgram",
     "BpfMap",
     "BpfLink",
+    "BpfRingBuffer",
     # Collections
     "MapCollection",
     "ProgramCollection",

--- a/tests/bpf/test_ringbuf.bpf.c
+++ b/tests/bpf/test_ringbuf.bpf.c
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0
+// Test eBPF program with ring buffer for testing tinybpf
+
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+char LICENSE[] SEC("license") = "GPL";
+
+struct event {
+    __u32 pid;
+    __u32 tid;
+    char comm[16];
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 256 * 1024);
+} events SEC(".maps");
+
+SEC("tracepoint/syscalls/sys_enter_execve")
+int trace_execve(void *ctx)
+{
+    struct event *e;
+
+    e = bpf_ringbuf_reserve(&events, sizeof(*e), 0);
+    if (!e)
+        return 0;
+
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    e->pid = pid_tgid >> 32;
+    e->tid = pid_tgid;
+    bpf_get_current_comm(&e->comm, sizeof(e->comm));
+
+    bpf_ringbuf_submit(e, 0);
+    return 0;
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,6 +20,7 @@ def test_exports():
         "BpfProgram",
         "BpfMap",
         "BpfLink",
+        "BpfRingBuffer",
         # Collections
         "MapCollection",
         "ProgramCollection",


### PR DESCRIPTION
## Summary

- Add `BpfRingBuffer` class for consuming events from `BPF_MAP_TYPE_RINGBUF` maps
- Ring buffers (kernel 5.8+) are the modern replacement for perf buffers
- Callback-based API matching libbpf's `ring_buffer__poll()`

## Features

- `poll(timeout_ms)` - Wait for and consume events with callback
- `consume()` - Consume all available events without waiting
- Safe exception handling (catch in callback, re-raise after poll returns)
- Map type validation in constructor
- Use-after-close detection
- Context manager support

## Test plan

- [x] `test_ringbuf_creation` - Basic creation and close
- [x] `test_ringbuf_wrong_map_type` - Error on non-ringbuf map
- [x] `test_ringbuf_poll_events` - End-to-end event polling
- [x] `test_ringbuf_callback_exception` - Exception propagation
- [x] `test_ringbuf_use_after_close` - Error on closed ring buffer
- [x] `test_ringbuf_use_after_object_close` - Error on closed BpfObject
- [x] `test_ringbuf_context_manager` - Context manager protocol

All 40 tests pass.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)