### PR TITLE
Add perf buffer support

### DIFF
--- a/src/tinybpf/__init__.py
+++ b/src/tinybpf/__init__.py
@@ -20,6 +20,7 @@ from tinybpf._object import (
     BpfMap,
     BpfMapType,
     BpfObject,
+    BpfPerfBuffer,
     BpfProgram,
     BpfProgType,
     BpfRingBuffer,
@@ -48,6 +49,7 @@ __all__ = [
     "BpfProgram",
     "BpfMap",
     "BpfLink",
+    "BpfPerfBuffer",
     "BpfRingBuffer",
     # Collections
     "MapCollection",

--- a/tests/bpf/test_perf.bpf.c
+++ b/tests/bpf/test_perf.bpf.c
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0
+// Test eBPF program with perf buffer for testing tinybpf
+
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+char LICENSE[] SEC("license") = "GPL";
+
+struct event {
+    __u32 pid;
+    __u32 cpu;
+    char comm[16];
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, sizeof(__u32));
+} events SEC(".maps");
+
+SEC("tracepoint/syscalls/sys_enter_getpid")
+int trace_getpid(void *ctx)
+{
+    struct event e = {};
+
+    e.pid = bpf_get_current_pid_tgid() >> 32;
+    e.cpu = bpf_get_smp_processor_id();
+    bpf_get_current_comm(&e.comm, sizeof(e.comm));
+
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &e, sizeof(e));
+    return 0;
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,6 +20,7 @@ def test_exports():
         "BpfProgram",
         "BpfMap",
         "BpfLink",
+        "BpfPerfBuffer",
         "BpfRingBuffer",
         # Collections
         "MapCollection",

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -420,3 +420,124 @@ class TestBpfRingBuffer:
                 assert "open" in repr(rb)
             # Ring buffer should be closed after with block
             assert "closed" in repr(rb)
+
+
+class TestBpfPerfBuffer:
+    """Tests for perf buffer operations."""
+
+    @pytest.fixture
+    def perf_bpf_path(self) -> Path:
+        """Path to compiled test_perf.bpf.o test program."""
+        path = BPF_DIR / "test_perf.bpf.o"
+        if not path.exists():
+            pytest.skip(f"Compiled BPF program not found: {path}")
+        return path
+
+    def test_perfbuf_creation(self, perf_bpf_path: Path) -> None:
+        """Can create perf buffer from perf event array map."""
+        def callback(cpu: int, data: bytes) -> None:
+            pass
+
+        with tinybpf.load(perf_bpf_path) as obj:
+            pb = tinybpf.BpfPerfBuffer(obj.map("events"), callback)
+            assert "open" in repr(pb)
+            pb.close()
+            assert "closed" in repr(pb)
+
+    def test_perfbuf_wrong_map_type(self, test_maps_bpf_path: Path) -> None:
+        """Creating perf buffer from non-perf-event-array map raises BpfError."""
+        with tinybpf.load(test_maps_bpf_path) as obj:
+            hash_map = obj.map("pid_counts")
+            with pytest.raises(tinybpf.BpfError, match="PERF_EVENT_ARRAY"):
+                tinybpf.BpfPerfBuffer(hash_map, lambda cpu, data: None)
+
+    def test_perfbuf_invalid_page_count(self, perf_bpf_path: Path) -> None:
+        """Invalid page_count raises ValueError."""
+        with tinybpf.load(perf_bpf_path) as obj:
+            with pytest.raises(ValueError, match="power of 2"):
+                tinybpf.BpfPerfBuffer(obj.map("events"), lambda c, d: None, page_count=3)
+
+    def test_perfbuf_poll_events(self, perf_bpf_path: Path) -> None:
+        """Can poll and receive events with CPU info."""
+        import os
+
+        events: list[tuple[int, bytes]] = []
+
+        def callback(cpu: int, data: bytes) -> None:
+            events.append((cpu, data))
+
+        with tinybpf.load(perf_bpf_path) as obj:
+            prog = obj.program("trace_getpid")
+            with prog.attach() as link:
+                with tinybpf.BpfPerfBuffer(obj.map("events"), callback) as pb:
+                    # Trigger getpid to generate event
+                    os.getpid()
+                    pb.poll(timeout_ms=100)
+
+        assert len(events) >= 1
+        cpu, data = events[0]
+        assert isinstance(cpu, int)
+        assert cpu >= 0
+        # Verify event structure (pid, cpu, comm) = 4 + 4 + 16 = 24 bytes minimum
+        # (actual size may include padding)
+        assert len(data) >= 24
+        # Verify we can extract the expected fields
+        pid = int.from_bytes(data[0:4], "little")
+        event_cpu = int.from_bytes(data[4:8], "little")
+        assert pid > 0
+        assert event_cpu >= 0
+
+    def test_perfbuf_lost_callback(self, perf_bpf_path: Path) -> None:
+        """Lost callback is invoked (basic wiring test)."""
+        lost_events: list[tuple[int, int]] = []
+
+        def sample_cb(cpu: int, data: bytes) -> None:
+            pass
+
+        def lost_cb(cpu: int, count: int) -> None:
+            lost_events.append((cpu, count))
+
+        with tinybpf.load(perf_bpf_path) as obj:
+            # Just test that it can be created with lost callback
+            with tinybpf.BpfPerfBuffer(obj.map("events"), sample_cb, lost_cb) as pb:
+                assert pb is not None
+
+    def test_perfbuf_callback_exception(self, perf_bpf_path: Path) -> None:
+        """Exception in callback is propagated."""
+        import os
+
+        def bad_callback(cpu: int, data: bytes) -> None:
+            raise ValueError("test error")
+
+        with tinybpf.load(perf_bpf_path) as obj:
+            prog = obj.program("trace_getpid")
+            with prog.attach() as link:
+                with tinybpf.BpfPerfBuffer(obj.map("events"), bad_callback) as pb:
+                    os.getpid()
+                    with pytest.raises(ValueError, match="test error"):
+                        pb.poll(timeout_ms=100)
+
+    def test_perfbuf_use_after_close(self, perf_bpf_path: Path) -> None:
+        """Using perf buffer after close raises BpfError."""
+        with tinybpf.load(perf_bpf_path) as obj:
+            pb = tinybpf.BpfPerfBuffer(obj.map("events"), lambda c, d: None)
+            pb.close()
+            with pytest.raises(tinybpf.BpfError, match="closed"):
+                pb.poll()
+
+    def test_perfbuf_use_after_object_close(self, perf_bpf_path: Path) -> None:
+        """Using perf buffer after BpfObject close raises BpfError."""
+        obj = tinybpf.load(perf_bpf_path)
+        pb = tinybpf.BpfPerfBuffer(obj.map("events"), lambda c, d: None)
+        obj.close()
+        with pytest.raises(tinybpf.BpfError, match="closed"):
+            pb.poll()
+        pb.close()
+
+    def test_perfbuf_context_manager(self, perf_bpf_path: Path) -> None:
+        """Perf buffer supports context manager protocol."""
+        with tinybpf.load(perf_bpf_path) as obj:
+            with tinybpf.BpfPerfBuffer(obj.map("events"), lambda c, d: None) as pb:
+                assert "open" in repr(pb)
+            # Perf buffer should be closed after with block
+            assert "closed" in repr(pb)


### PR DESCRIPTION
## Summary
- Add `BpfPerfBuffer` class for consuming events from `BPF_MAP_TYPE_PERF_EVENT_ARRAY` maps
- Enables event streaming on older kernels (4.4+) compared to ring buffers (5.8+)
- Sample callback includes CPU info: `(cpu: int, data: bytes) -> None`
- Optional lost event callback: `(cpu: int, count: int) -> None`
- Adds 9 new tests (49 total)

## Test plan
- [x] All existing tests pass (40 tests)
- [x] New perf buffer tests pass (9 tests)
- [x] Test BPF program compiles successfully
- [x] Manual verification of event polling works

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)