### PR TITLE
Add async/await support for ring buffer polling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ setup-linux:
 		tar xz -C src/tinybpf/_libbpf/)
 
 test-linux: compile setup-linux
-	uv run --with pytest pytest tests/ -v
+	uv run --with pytest --with pytest-asyncio pytest tests/ -v
 
 #
 # macOS/Lima targets (run Linux targets inside Lima VM)
@@ -56,7 +56,7 @@ setup-lima:
 	limactl shell $(LIMA_VM) -- make -C $(PROJECT_DIR) setup-linux
 
 test-lima: compile setup-lima
-	limactl shell $(LIMA_VM) -- bash -c 'sudo $$HOME/.local/bin/uv run --project $(PROJECT_DIR) --with pytest pytest $(PROJECT_DIR)/tests -v'
+	limactl shell $(LIMA_VM) -- bash -c 'sudo $$HOME/.local/bin/uv run --project $(PROJECT_DIR) --with pytest --with pytest-asyncio pytest $(PROJECT_DIR)/tests -v'
 
 #
 # Auto-detect OS and dispatch to appropriate target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = ["pytest", "pytest-asyncio"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -32,3 +32,6 @@ include-package-data = false
 [tool.setuptools.package-data]
 "tinybpf._libbpf" = ["*.so*"]
 "tinybpf" = ["py.typed"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/src/tinybpf/_libbpf/bindings.py
+++ b/src/tinybpf/_libbpf/bindings.py
@@ -219,6 +219,9 @@ def _setup_function_signatures(lib: ctypes.CDLL) -> None:
     ]
     lib.ring_buffer__add.restype = ctypes.c_int
 
+    lib.ring_buffer__epoll_fd.argtypes = [ring_buffer_p]
+    lib.ring_buffer__epoll_fd.restype = ctypes.c_int
+
     # Perf buffer functions
     lib.perf_buffer__new.argtypes = [
         ctypes.c_int,  # map_fd

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -121,6 +130,40 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version == '3.10.*'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "tinybpf"
 version = "0.0.1"
 source = { editable = "." }
@@ -129,10 +172,15 @@ source = { editable = "." }
 dev = [
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pytest", marker = "extra == 'dev'" }]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'" },
+]
 provides-extras = ["dev"]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `poll_async()` method for asyncio-native event polling using `ring_buffer__epoll_fd()`
- Supports async iteration: `async for event in rb:` for iterator mode consumption
- Exposes `epoll_fd()`/`fileno()` for custom event loop integration
- Adds async context manager support (`async with BpfRingBuffer(...) as rb:`)

This builds on the multi-map ring buffer support (#17) to add two consumption modes:
- **Callback mode**: pass callback to constructor/add(), events delivered during poll()
- **Iterator mode**: omit callback, use async iteration to consume events

## Test plan

- [x] All 69 tests pass including new async tests
- [x] `test_ringbuf_poll_async_callback` - verify async poll with callbacks
- [x] `test_ringbuf_poll_async_timeout` - verify timeout behavior
- [x] `test_ringbuf_async_iterator` - verify async iteration yields events
- [x] `test_ringbuf_mode_mixing_error` - verify modes cannot be mixed
- [x] `test_ringbuf_iterate_on_callback_mode_error` - verify iteration error on callback mode

**Note:** This PR depends on #17 (multi-map ring buffer support) and targets that branch.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)