### PR TITLE
Add tagged events async iterator for ring buffer

### DIFF
--- a/src/tinybpf/__init__.py
+++ b/src/tinybpf/__init__.py
@@ -28,6 +28,7 @@ from tinybpf._object import (
     MapInfo,
     ProgramCollection,
     ProgramInfo,
+    RingBufferEvent,
     load,
 )
 
@@ -57,6 +58,7 @@ __all__ = [
     # Data classes
     "MapInfo",
     "ProgramInfo",
+    "RingBufferEvent",
     # Enums
     "BpfMapType",
     "BpfProgType",


### PR DESCRIPTION
## Summary

- Adds `rb.events()` method returning async iterator of `RingBufferEvent` objects
- Each event includes `map_name` and `data` fields for multi-map identification
- Backward compatible: existing `async for data in rb:` still yields raw `bytes`
- Internal queue now stores `(map_name, bytes)` tuples; default iterator discards tag

## API

```python
# Existing (unchanged)
async for data in rb:
    handle(data)  # bytes

# New tagged iterator
async for event in rb.events():
    if event.map_name == "events1":
        handle_type1(event.data)
    else:
        handle_type2(event.data)
```

## Test plan

- [x] All 73 tests pass
- [x] `test_ringbuf_tagged_events_single_map` - events include map name
- [x] `test_ringbuf_tagged_events_multi_map` - correct map names for multi-map
- [x] `test_ringbuf_tagged_events_on_callback_mode_error` - error in callback mode
- [x] `test_ringbuf_event_dataclass` - RingBufferEvent has expected attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)