### PR TITLE
Add support for pinned BPF maps

### DIFF
--- a/src/tinybpf/__init__.py
+++ b/src/tinybpf/__init__.py
@@ -13,7 +13,7 @@ __version__ = "0.0.1"
 from tinybpf._buffers import BpfPerfBuffer, BpfRingBuffer
 from tinybpf._libbpf import init, libbpf_version
 from tinybpf._link import BpfLink
-from tinybpf._map import BpfMap, MapCollection
+from tinybpf._map import BpfMap, MapCollection, open_pinned_map
 from tinybpf._object import BpfObject, load
 from tinybpf._program import BpfProgram, ProgramCollection
 from tinybpf._types import (
@@ -41,6 +41,7 @@ __all__ = [
     "libbpf_version",
     # Main API
     "load",
+    "open_pinned_map",
     # Classes
     "BpfObject",
     "BpfProgram",

--- a/src/tinybpf/_buffers.py
+++ b/src/tinybpf/_buffers.py
@@ -232,7 +232,8 @@ class BpfRingBuffer:
 
         # Track for lifecycle management
         self._maps.append(map)
-        self._objs.add(map._obj)
+        if map._obj is not None:
+            self._objs.add(map._obj)
         self._callbacks.append(cb)
 
     def _check_open(self) -> None:
@@ -664,7 +665,7 @@ class BpfPerfBuffer:
         """Raise if parent BpfObject is closed or perf buffer is closed."""
         if self._closed:
             raise BpfError("Perf buffer is closed")
-        if self._obj._closed:
+        if self._obj is not None and self._obj._closed:
             raise BpfError("Cannot use perf buffer after BpfObject is closed")
 
     def _check_and_reraise(self) -> None:

--- a/src/tinybpf/_libbpf/bindings.py
+++ b/src/tinybpf/_libbpf/bindings.py
@@ -184,6 +184,25 @@ def _setup_function_signatures(lib: ctypes.CDLL) -> None:
     lib.bpf_map_get_next_key.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p]
     lib.bpf_map_get_next_key.restype = ctypes.c_int
 
+    # Map pinning
+    lib.bpf_map__pin.argtypes = [bpf_map_p, ctypes.c_char_p]
+    lib.bpf_map__pin.restype = ctypes.c_int
+
+    lib.bpf_map__unpin.argtypes = [bpf_map_p, ctypes.c_char_p]
+    lib.bpf_map__unpin.restype = ctypes.c_int
+
+    # Open pinned BPF object (returns fd)
+    lib.bpf_obj_get.argtypes = [ctypes.c_char_p]
+    lib.bpf_obj_get.restype = ctypes.c_int
+
+    # Get BPF object info by fd (works for maps, programs, etc.)
+    lib.bpf_obj_get_info_by_fd.argtypes = [
+        ctypes.c_int,  # fd
+        ctypes.c_void_p,  # info struct
+        ctypes.POINTER(ctypes.c_uint32),  # info_len
+    ]
+    lib.bpf_obj_get_info_by_fd.restype = ctypes.c_int
+
     # Error handling
     lib.libbpf_strerror.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_size_t]
     lib.libbpf_strerror.restype = ctypes.c_int

--- a/src/tinybpf/_types.py
+++ b/src/tinybpf/_types.py
@@ -10,6 +10,7 @@ This module contains foundational types used throughout tinybpf:
 
 from __future__ import annotations
 
+import ctypes
 from dataclasses import dataclass
 from enum import IntEnum
 from typing import Any
@@ -104,6 +105,28 @@ class BpfProgType(IntEnum):
 BPF_ANY = 0  # Create new or update existing
 BPF_NOEXIST = 1  # Create new only if it doesn't exist
 BPF_EXIST = 2  # Update existing only
+
+# BPF object name length (from kernel)
+BPF_OBJ_NAME_LEN = 16
+
+
+class _BpfMapInfoKernel(ctypes.Structure):
+    """Kernel bpf_map_info structure for bpf_obj_get_info_by_fd.
+
+    This is a subset of the full struct - only fields we need.
+    The kernel will fill in what it knows and ignore extra space.
+    """
+
+    _fields_ = [  # noqa: RUF012 (required by ctypes.Structure)
+        ("type", ctypes.c_uint32),
+        ("id", ctypes.c_uint32),
+        ("key_size", ctypes.c_uint32),
+        ("value_size", ctypes.c_uint32),
+        ("max_entries", ctypes.c_uint32),
+        ("map_flags", ctypes.c_uint32),
+        ("name", ctypes.c_char * BPF_OBJ_NAME_LEN),
+        # Additional fields exist but aren't needed for basic functionality
+    ]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

- Enable pinning maps to bpffs and opening previously pinned maps
- Supports privileged loader + unprivileged worker patterns
- `map.pin(path)` / `map.unpin(path)` for object-owned maps
- `tinybpf.open_pinned_map(path)` returns standalone BpfMap with context manager support

## Test plan

- [x] `test_pin_map` - Pin a map, verify file exists
- [x] `test_unpin_map` - Unpin a map, verify file removed
- [x] `test_open_pinned_map` - Open pinned map, verify metadata
- [x] `test_pinned_map_operations` - CRUD on pinned map
- [x] `test_pinned_map_data_persists` - Data survives across opens
- [x] `test_pinned_map_iteration` - Iterate over pinned map entries
- [x] `test_pinned_map_use_after_close` - Error on use after close
- [x] `test_pin_standalone_map_raises` - Error when pinning standalone map
- [x] `test_open_nonexistent_pinned_map` - Error on invalid path

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)