### PR TITLE
Add XDP program attachment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Attach methods:
 - `attach_raw_tracepoint(name)`
 - `attach_uprobe(binary_path, offset=0, pid=-1, retprobe=False)`
 - `attach_uretprobe(binary_path, offset=0, pid=-1)`
+- `attach_xdp(ifindex)` - Attach XDP to network interface
 
 Properties: `name`, `section`, `type`, `fd`, `info`
 

--- a/llms.txt
+++ b/llms.txt
@@ -38,6 +38,7 @@ prog.attach_tracepoint("category", "name")
 prog.attach_raw_tracepoint("name")
 prog.attach_uprobe(binary, offset=0, pid=-1, retprobe=False)
 prog.attach_uretprobe(binary, offset=0, pid=-1)
+prog.attach_xdp(ifindex)  # XDP on network interface (use socket.if_nametoindex)
 prog.name, prog.section, prog.type, prog.fd, prog.info
 
 # BpfMap - dict-like interface

--- a/src/tinybpf/_libbpf/bindings.py
+++ b/src/tinybpf/_libbpf/bindings.py
@@ -137,6 +137,9 @@ def _setup_function_signatures(lib: ctypes.CDLL) -> None:
     lib.bpf_program__attach_raw_tracepoint.argtypes = [bpf_program_p, ctypes.c_char_p]
     lib.bpf_program__attach_raw_tracepoint.restype = bpf_link_p
 
+    lib.bpf_program__attach_xdp.argtypes = [bpf_program_p, ctypes.c_int]
+    lib.bpf_program__attach_xdp.restype = bpf_link_p
+
     # Link operations
     lib.bpf_link__destroy.argtypes = [bpf_link_p]
     lib.bpf_link__destroy.restype = ctypes.c_int

--- a/src/tinybpf/_program.py
+++ b/src/tinybpf/_program.py
@@ -202,6 +202,25 @@ class BpfProgram:
         """
         return self.attach_uprobe(binary_path, offset, pid, retprobe=True)
 
+    def attach_xdp(self, ifindex: int) -> BpfLink:
+        """Attach XDP program to a network interface.
+
+        Args:
+            ifindex: Network interface index. Use socket.if_nametoindex("eth0")
+                     to convert an interface name to its index.
+
+        Returns:
+            A BpfLink that can be used to manage the attachment.
+
+        Raises:
+            BpfError: If attachment fails.
+        """
+        self._check_open()
+        lib = bindings._get_lib()
+        link = lib.bpf_program__attach_xdp(self._ptr, ifindex)
+        _check_ptr(link, f"attach XDP to interface {ifindex}")
+        return BpfLink(link, f"xdp:if{ifindex}")
+
 
 class ProgramCollection(Mapping[str, BpfProgram]):
     """Collection of BPF programs in an object, accessible by name."""

--- a/tests/bpf/test_xdp.bpf.c
+++ b/tests/bpf/test_xdp.bpf.c
@@ -1,0 +1,10 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+char LICENSE[] SEC("license") = "GPL";
+
+SEC("xdp")
+int xdp_pass(struct xdp_md *ctx)
+{
+    return XDP_PASS;
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ Fixtures:
 - test_maps_bpf_path: Path to test_maps.bpf.o (hash, array, percpu maps)
 - ringbuf_bpf_path: Path to test_ringbuf.bpf.o (ring buffer maps)
 - perf_bpf_path: Path to test_perf.bpf.o (perf event array)
+- xdp_bpf_path: Path to test_xdp.bpf.o (XDP program)
 
 All integration tests require root privileges (CAP_BPF, CAP_SYS_ADMIN).
 """
@@ -88,6 +89,19 @@ def perf_bpf_path() -> Path:
     - trace_getpid: tracepoint, outputs perf events with CPU context
     """
     path = BPF_DIR / "test_perf.bpf.o"
+    if not path.exists():
+        pytest.skip(f"Compiled BPF program not found: {path}")
+    return path
+
+
+@pytest.fixture
+def xdp_bpf_path() -> Path:
+    """Path to compiled test_xdp.bpf.o test program.
+
+    Contains programs:
+    - xdp_pass: XDP program that passes all packets
+    """
+    path = BPF_DIR / "test_xdp.bpf.o"
     if not path.exists():
         pytest.skip(f"Compiled BPF program not found: {path}")
     return path

--- a/tests/test_programs.py
+++ b/tests/test_programs.py
@@ -70,6 +70,34 @@ class TestKprobeAttachment:
             link.destroy()
 
 
+class TestXdpAttachment:
+    """Tests for XDP attachment."""
+
+    def test_attach_xdp(self, xdp_bpf_path: Path) -> None:
+        """Can attach XDP program to loopback interface."""
+        import socket
+
+        with tinybpf.load(xdp_bpf_path) as obj:
+            prog = obj.program("xdp_pass")
+            ifindex = socket.if_nametoindex("lo")
+            link = prog.attach_xdp(ifindex)
+            assert link.fd >= 0
+            assert "xdp" in repr(link)
+            link.destroy()
+            assert link.fd == -1
+
+    def test_attach_xdp_context_manager(self, xdp_bpf_path: Path) -> None:
+        """XDP link supports context manager protocol."""
+        import socket
+
+        with tinybpf.load(xdp_bpf_path) as obj:
+            prog = obj.program("xdp_pass")
+            ifindex = socket.if_nametoindex("lo")
+            with prog.attach_xdp(ifindex) as link:
+                assert link.fd >= 0
+            assert link.fd == -1
+
+
 class TestProgramAttachmentErrors:
     """Tests for program attachment error handling."""
 


### PR DESCRIPTION
## Summary

- Add `attach_xdp(ifindex)` method to `BpfProgram` for attaching XDP programs to network interfaces
- Use `socket.if_nametoindex("eth0")` to convert interface name to index

## Test plan

- [x] `test_attach_xdp` - Attach XDP program to loopback, verify link
- [x] `test_attach_xdp_context_manager` - Context manager cleanup

Tests attach to loopback interface which is available on all Linux systems (Lima VM locally, GitHub runners in CI).

🤖 Generated with [Claude Code](https://claude.ai/code)