### PR TITLE
Fix docker-compile -o flag passed to docker instead of container

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -150,7 +150,7 @@ tinybpf provides a Docker image for compiling eBPF programs. It bundles libbpf h
 make compile
 
 # Advanced: run docker directly (on Linux, or inside Lima shell on macOS)
-docker run --rm -v $(pwd):/src ghcr.io/gregclermont/tinybpf-compile -o build/ src/*.bpf.c
+docker run --rm -v $(pwd):/src ghcr.io/gregclermont/tinybpf-compile src/*.bpf.c -o build/
 docker run --rm -v $(pwd):/src -e EXTRA_CFLAGS="-DDEBUG" ghcr.io/gregclermont/tinybpf-compile program.bpf.c
 ```
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -14,7 +14,7 @@ tinybpf docker-compile program.bpf.c
 tinybpf docker-compile src/*.bpf.c
 
 # Output to specific directory
-tinybpf docker-compile -o build/ src/*.bpf.c
+tinybpf docker-compile src/*.bpf.c -o build/
 ```
 
 The CLI uses a Docker image with libbpf headers and `vmlinux.h` (kernel 6.18) for CO-RE support. Output `.bpf.o` files are written alongside sources (or to the specified output directory).

--- a/llms.txt
+++ b/llms.txt
@@ -145,7 +145,7 @@ BtfKind.INT, STRUCT, UNION, ARRAY, PTR, TYPEDEF, FLOAT, ...  # BTF type kinds
 
 ```bash
 tinybpf docker-compile program.bpf.c
-tinybpf docker-compile -o build/ src/*.bpf.c
+tinybpf docker-compile src/*.bpf.c -o build/
 ```
 
 Uses a Docker image with libbpf headers and vmlinux.h (kernel 6.18, x86_64/aarch64) for CO-RE support. Output `.bpf.o` files are written alongside sources or to specified output directory.

--- a/src/tinybpf/_cli.py
+++ b/src/tinybpf/_cli.py
@@ -52,14 +52,13 @@ def cmd_docker_compile(args: argparse.Namespace) -> int:
         "--rm",
         "-v",
         f"{cwd}:/src",
+        image_tag,
+        *args.sources,
     ]
 
     # Pass through output directory if specified
     if args.output:
         docker_cmd.extend(["-o", args.output])
-
-    docker_cmd.append(image_tag)
-    docker_cmd.extend(args.sources)
 
     if args.verbose:
         print(f"Running: {' '.join(docker_cmd)}", file=sys.stderr)


### PR DESCRIPTION
## Summary

- Fixed bug where `-o`/`--output` flag was passed as a docker argument instead of being passed to the container's entrypoint
- Updated entrypoint.sh to accept `-o` flag in any position (before or after sources)
- Updated docs to use more intuitive `src/*.bpf.c -o build/` ordering

Fixes #60

## Test plan

- [x] Tested locally with `tinybpf docker-compile -v --output dist/bpf/ tests/bpf/minimal.bpf.c`
- [x] Built docker image locally and verified both orderings work:
  - `src/*.bpf.c -o build/` ✓
  - `-o build/ src/*.bpf.c` ✓
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)